### PR TITLE
에러/메세지 팝업에 엔터 키 입력으로 폼 이벤트가 다시 전송되는 오류 수정

### DIFF
--- a/app/src/components/Button/Button.jsx
+++ b/app/src/components/Button/Button.jsx
@@ -1,10 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { forwardRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import './Button.scss';
 
 import ReactTooltip from 'react-tooltip';
 
-function Button(props) {
+const Button = forwardRef((props, forwardedRef) => {
   const { className, type, size, outline, children, shadow, color, rounded, onClick, disabled, tip } = props;
 
   useEffect(() => {
@@ -13,6 +13,7 @@ function Button(props) {
 
   return (
     <button
+      ref={forwardedRef}
       type={type}
       className={`g-no-select btn-wrapper btn${outline ? '-outline' : ''} btn-${color ? `${color}` : ''} btn-${size} ${className} ${disabled ? 'disabled' : ''} ${shadow ? '' : 'shadow-none'} ${
         rounded ? 'rounded' : ''
@@ -25,7 +26,7 @@ function Button(props) {
       {children}
     </button>
   );
-}
+});
 
 Button.defaultProps = {
   className: '',

--- a/app/src/pages/common/ErrorDialog.jsx
+++ b/app/src/pages/common/ErrorDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import useStores from '@/hooks/useStores';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
@@ -8,6 +8,7 @@ import './CommonDialog.scss';
 function ErrorDialog({ className, title, message, handler }) {
   const { t } = useTranslation();
   const { controlStore } = useStores();
+  const buttonElement = useRef(null);
 
   const onKeyDown = e => {
     if (e.keyCode === 13 || e.keyCode === 27) {
@@ -17,6 +18,10 @@ function ErrorDialog({ className, title, message, handler }) {
 
   useEffect(() => {
     document.addEventListener('keydown', onKeyDown);
+    if (buttonElement.current) {
+      buttonElement.current.focus();
+    }
+
     return () => {
       document.removeEventListener('keydown', onKeyDown);
     };
@@ -44,6 +49,7 @@ function ErrorDialog({ className, title, message, handler }) {
       </ModalBody>
       <ModalFooter>
         <Button
+          ref={buttonElement}
           color="primary"
           onClick={() => {
             controlStore.setError(null);

--- a/app/src/pages/common/MessageDialog.jsx
+++ b/app/src/pages/common/MessageDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import useStores from '@/hooks/useStores';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +9,7 @@ import './CommonDialog.scss';
 function MessageDialog({ className, category, title, message, okHandler, okText }) {
   const { t } = useTranslation();
   const { controlStore } = useStores();
+  const buttonElement = useRef(null);
 
   const onKeyDown = e => {
     if (e.keyCode === 13 || e.keyCode === 27) {
@@ -18,6 +19,9 @@ function MessageDialog({ className, category, title, message, okHandler, okText 
 
   useEffect(() => {
     document.addEventListener('keydown', onKeyDown);
+    if (buttonElement.current) {
+      buttonElement.current.focus();
+    }
     return () => {
       document.removeEventListener('keydown', onKeyDown);
     };
@@ -48,6 +52,7 @@ function MessageDialog({ className, category, title, message, okHandler, okText 
       </ModalBody>
       <ModalFooter>
         <Button
+          ref={buttonElement}
           outline
           onClick={() => {
             controlStore.setMessage(null);


### PR DESCRIPTION
- 버튼 컴포넌트 forwardRef 처리
- 에러/메세지 팝업 오픈 시 확인 버튼에 포커스 처리