### PR TITLE
Fix/logout badge not init

### DIFF
--- a/app/src/pages/common/Header/Header.jsx
+++ b/app/src/pages/common/Header/Header.jsx
@@ -15,7 +15,7 @@ import SideControl from '@/pages/common/Header/SideControl';
 
 function Header({ className }) {
   const {
-    userStore: { isLogin, setUser },
+    userStore: { isLogin, setUser, setNotificationCount },
     themeStore: { theme },
   } = useStores();
 
@@ -36,6 +36,7 @@ function Header({ className }) {
     UserService.logout(
       () => {
         setUser(null);
+        setNotificationCount(0);
         navigate('/');
         setMobileMenuOpen(false);
       },

--- a/app/src/pages/common/Header/MobileMenu.jsx
+++ b/app/src/pages/common/Header/MobileMenu.jsx
@@ -13,7 +13,7 @@ import UserService from '@/services/UserService';
 
 function MobileMenu({ className, setOpen }) {
   const {
-    userStore: { isLogin, setUser },
+    userStore: { isLogin, setUser, setNotificationCount },
     contextStore: { spaceCode, projectId, isProjectSelected },
   } = useStores();
 
@@ -31,6 +31,7 @@ function MobileMenu({ className, setOpen }) {
     UserService.logout(
       () => {
         setUser(null);
+        setNotificationCount(0);
         navigate('/');
       },
       () => {

--- a/app/src/pages/common/Header/SideControl.jsx
+++ b/app/src/pages/common/Header/SideControl.jsx
@@ -107,10 +107,12 @@ function SideControl({ className }) {
     UserService.logout(
       () => {
         setUser(null);
+        setNotificationCount(0);
         navigate('/');
       },
       () => {
         setUser(null);
+        setNotificationCount(0);
         navigate('/');
       },
     );

--- a/app/src/pages/common/Header/UserHeaderControl.jsx
+++ b/app/src/pages/common/Header/UserHeaderControl.jsx
@@ -14,7 +14,7 @@ import { ADMIN_MENUS } from '@/constants/menu';
 
 function UserHeaderControl({ className }) {
   const {
-    userStore: { isAdmin, setUser, notificationCount, setNotificationCount },
+    userStore: { isAdmin, user, setUser, notificationCount, setNotificationCount },
   } = useStores();
 
   const navigate = useNavigate();
@@ -108,6 +108,7 @@ function UserHeaderControl({ className }) {
     UserService.logout(
       () => {
         setUser(null);
+        setNotificationCount(0);
         navigate('/');
       },
       () => {
@@ -149,42 +150,45 @@ function UserHeaderControl({ className }) {
           </ul>
         </div>
       )}
-      <div className="notification-menu side-menu-item">
-        <Button
-          outline
-          rounded
-          className={notificationChangeEffect ? 'effect' : ''}
-          color={notificationOpen ? 'primary' : 'white'}
-          onClick={e => {
-            e.preventDefault();
-            openUserNotificationPopup(true);
-          }}
-        >
-          {notificationCount > 0 && (
-            <span className="notification-count">
-              <span>{notificationCount > 9 ? '9+' : notificationCount}</span>
-            </span>
-          )}
-          <i className="fa-solid fa-bell" />
-        </Button>
-      </div>
-      <div className="user-menu side-menu-item">
-        <Button
-          outline
-          rounded
-          color={userMenuOpen ? 'primary' : 'white'}
-          onClick={e => {
-            e.preventDefault();
-            setUserMenuOpen(true);
-          }}
-        >
-          {isAdmin && <div className="admin-flag">ADMIN</div>}
-          <div className="icon">
-            <i className="fa-solid fa-skull" />
+      {user?.id && (
+        <>
+          <div className="notification-menu side-menu-item">
+            <Button
+              outline
+              rounded
+              className={notificationChangeEffect ? 'effect' : ''}
+              color={notificationOpen ? 'primary' : 'white'}
+              onClick={e => {
+                e.preventDefault();
+                openUserNotificationPopup(true);
+              }}
+            >
+              {notificationCount > 0 && (
+                <span className="notification-count">
+                  <span>{notificationCount > 9 ? '9+' : notificationCount}</span>
+                </span>
+              )}
+              <i className="fa-solid fa-bell" />
+            </Button>
           </div>
-        </Button>
-      </div>
-
+          <div className="user-menu side-menu-item">
+            <Button
+              outline
+              rounded
+              color={userMenuOpen ? 'primary' : 'white'}
+              onClick={e => {
+                e.preventDefault();
+                setUserMenuOpen(true);
+              }}
+            >
+              {isAdmin && <div className="admin-flag">ADMIN</div>}
+              <div className="icon">
+                <i className="fa-solid fa-skull" />
+              </div>
+            </Button>
+          </div>
+        </>
+      )}
       {notificationOpen && (
         <div
           className="notification-list"

--- a/app/src/pages/spaces/SpaceInfoPage/SpaceContent.jsx
+++ b/app/src/pages/spaces/SpaceInfoPage/SpaceContent.jsx
@@ -212,7 +212,7 @@ function SpaceContent({ space, onRefresh }) {
         <Block>
           <MemberCardManager users={users} />
         </Block>
-        {isAdmin && space?.admin && (
+        {(isAdmin || space?.admin) && (
           <>
             <Title
               control={statusOptions.map(option => {

--- a/src/main/java/com/mindplates/bugcase/biz/space/repository/SpaceRepository.java
+++ b/src/main/java/com/mindplates/bugcase/biz/space/repository/SpaceRepository.java
@@ -16,5 +16,7 @@ public interface SpaceRepository extends JpaRepository<Space, Long> {
 
     List<Space> findAllByNameLikeAndAllowSearchTrueOrCodeLikeAndAllowSearchTrue(String name, String code);
 
+    Long countByCode(String code);
+
 }
 

--- a/src/main/java/com/mindplates/bugcase/biz/space/service/SpaceService.java
+++ b/src/main/java/com/mindplates/bugcase/biz/space/service/SpaceService.java
@@ -78,10 +78,20 @@ public class SpaceService {
         spaceRepository.deleteById(space.getId());
     }
 
+    public boolean existByCode(String code) {
+        Long count = spaceRepository.countByCode(code);
+        return count > 0;
+    }
+
 
     @CacheEvict(key = "#createSpaceInfo.code", value = CacheConfig.SPACE)
     @Transactional
     public SpaceDTO createSpaceInfo(SpaceDTO createSpaceInfo, Long userId) {
+
+        if (existByCode(createSpaceInfo.getCode())) {
+            throw new ServiceException("error.space.code.duplicated");
+        }
+
         Space spaceInfo = mappingUtil.convert(createSpaceInfo, Space.class);
         SpaceUser spaceUser = SpaceUser.builder().space(spaceInfo).user(User.builder().id(userId).build()).role(UserRoleCode.ADMIN).build();
         spaceInfo.setUsers(Arrays.asList(spaceUser));

--- a/src/main/resources/messages/message.properties
+++ b/src/main/resources/messages/message.properties
@@ -6,6 +6,7 @@ no.space.admin.exist=탈퇴하려는 스페이스에 다른 어드민이 존재�
 at.least.one.space.admin=최소 1명의 스페이스 관리자는 지정되어야 합니다.
 error.login=일치하는 사용자 정보를 찾을 수 없습니다.
 no.project.admin.exist=탈퇴하려는 프로젝트에 다른 어드민이 존재하지 않아서, 탈퇴할 수 없습니다.
+error.space.code.duplicated=이미 사용중인 스페이스 코드입니다.
 error.project.duplicated=동일한 이름의 프로젝트가 존재합니다.
 error.exist.email=이미 가입된 이메일입니다.
 testrun.created=<{1}|"{0}" 테스트런>이 시작되었습니다.\n

--- a/src/main/resources/messages/message_en.properties
+++ b/src/main/resources/messages/message_en.properties
@@ -6,6 +6,7 @@ no.space.admin.exist=탈퇴하려는 스페이스에 다른 어드민이 존재�
 at.least.one.space.admin=최소 1명의 스페이스 관리자는 지정되어야 합니다.
 error.login=일치하는 사용자 정보를 찾을 수 없습니다.
 no.project.admin.exist=탈퇴하려는 프로젝트에 다른 어드민이 존재하지 않아서, 탈퇴할 수 없습니다.
+error.space.code.duplicated=이미 사용중인 스페이스 코드입니다.
 error.project.duplicated=동일한 이름의 프로젝트가 존재합니다.
 error.exist.email=이미 가입된 이메일입니다.
 testrun.created=<{1}|"{0}" 테스트런>이 시작되었습니다.\n

--- a/src/main/resources/messages/message_ko.properties
+++ b/src/main/resources/messages/message_ko.properties
@@ -6,6 +6,7 @@ no.space.admin.exist=탈퇴하려는 스페이스에 다른 어드민이 존재�
 at.least.one.space.admin=최소 1명의 스페이스 관리자는 지정되어야 합니다.
 error.login=일치하는 사용자 정보를 찾을 수 없습니다.
 no.project.admin.exist=탈퇴하려는 프로젝트에 다른 어드민이 존재하지 않아서, 탈퇴할 수 없습니다.
+error.space.code.duplicated=이미 사용중인 스페이스 코드입니다.
 error.project.duplicated=동일한 이름의 프로젝트가 존재합니다.
 error.exist.email=이미 가입된 이메일입니다.
 testrun.created=<{1}|"{0}" 테스트런>이 시작되었습니다.\n


### PR DESCRIPTION
### 📄 What is this PR? 
 - 로그아웃 시 배지 카운트 및 사용자 관련 메뉴가 헤더에 남아 있는 오류 수정
 - #141 

### 🛠 Changes
- 로그아웃 처리 핸들러에서 관련 정보 초기화 처리
- 사용자 ID가 있는 경우에만 사용자 관련 메뉴를 헤더에 노출하도록 수정

### 📸 Screenshots (Optional)
- 아래와 같이 배지가 있는 상태에서 
![image](https://github.com/case-book/casebook/assets/14084781/5a68577b-168f-4f31-b0a8-b9358c1b92eb)
- 로그아웃되게 되면, 배지 카운트 및 사용자 메뉴가 노출되는 오류 수정
![image](https://github.com/case-book/casebook/assets/14084781/c4ff5098-1979-4f61-aba4-3a55bf51842f)