### PR TITLE
테스트런 참가자 정보가 동기화 안되는 오류 수정

### DIFF
--- a/src/main/java/com/mindplates/bugcase/biz/testrun/controller/TestrunMessageController.java
+++ b/src/main/java/com/mindplates/bugcase/biz/testrun/controller/TestrunMessageController.java
@@ -7,15 +7,16 @@ import com.mindplates.bugcase.biz.user.service.UserService;
 import com.mindplates.bugcase.common.exception.ServiceException;
 import com.mindplates.bugcase.common.message.MessageSendService;
 import com.mindplates.bugcase.common.message.vo.MessageData;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -28,32 +29,52 @@ public class TestrunMessageController {
     private final MessageSendService messageSendService;
 
     @MessageMapping("/{testrunId}/join")
-    public void join(@DestinationVariable(value = "spaceCode") String spaceCode, @DestinationVariable(value = "projectId") Long projectId, @DestinationVariable(value = "testrunId") Long testrunId, SimpMessageHeaderAccessor headerAccessor) {
+    public void join(@DestinationVariable(value = "spaceCode") String spaceCode, @DestinationVariable(value = "projectId") Long projectId,
+        @DestinationVariable(value = "testrunId") Long testrunId, SimpMessageHeaderAccessor headerAccessor) {
 
         Map<String, Object> attributes = headerAccessor.getSessionAttributes();
         if (attributes == null) {
             throw new ServiceException("session.error.expired");
         }
 
+        String sessionId = headerAccessor.getSessionId();
+
         Long userId = Long.parseLong((String) attributes.get("USER-ID"));
         UserDTO user = userService.selectUserInfo(userId);
-        TestrunParticipantDTO testrunParticipant = testrunService.createTestrunParticipantInfo(spaceCode, projectId, testrunId, user);
+
+        // 이미 참가 중인 사용자가의 새로운 세션인지의 여부
+        boolean isAlreadyJoinedUser = testrunService.isExistParticipant(testrunId, userId);
+
+        TestrunParticipantDTO testrunParticipant = testrunService.createTestrunParticipantInfo(spaceCode, projectId, testrunId, user, sessionId);
 
         // 테스트런의 모든 참가자 정보를 등록된 사용자에게 전달
         List<TestrunParticipantDTO> participants = testrunService.selectTestrunParticipantList(spaceCode, projectId, testrunId);
+        Map<Long, Boolean> userIdMap = new HashMap<>();
+
+        List<TestrunParticipantDTO> uniqueParticipants = participants.stream().filter((participant -> {
+            if (!userIdMap.containsKey(participant.getUserId())) {
+                userIdMap.put(participant.getUserId(), true);
+                return true;
+            }
+
+            return false;
+        })).collect(Collectors.toList());
+
         MessageData participantsData = MessageData.builder().type("TESTRUN-PARTICIPANTS").build();
-        participantsData.addData("participants", participants);
+        participantsData.addData("participants", uniqueParticipants);
         messageSendService.sendTo("projects/" + projectId + "/testruns/" + testrunId + "/users/" + userId, participantsData);
 
-        // 테스트런에 참가자들에게 새로운 사용자 정보 전달
-        MessageData participantData = MessageData.builder().type("TESTRUN-USER-JOIN").build();
-        participantData.addData("participant" , testrunParticipant);
-        messageSendService.sendTo("projects/" + projectId + "/testruns/" + testrunId, participantData);
+        if (!isAlreadyJoinedUser) {
+            // 테스트런에 참가자들에게 새로운 사용자 정보 전달
+            MessageData participantData = MessageData.builder().type("TESTRUN-USER-JOIN").build();
+            participantData.addData("participant", testrunParticipant);
+            messageSendService.sendTo("projects/" + projectId + "/testruns/" + testrunId, participantData);
+        }
     }
 
     @MessageMapping("/{testrunId}/leave")
     public void leave(@DestinationVariable(value = "spaceCode") String spaceCode, @DestinationVariable(value = "projectId") Long projectId,
-                      @DestinationVariable(value = "testrunId") Long testrunId, SimpMessageHeaderAccessor headerAccessor) {
+        @DestinationVariable(value = "testrunId") Long testrunId, SimpMessageHeaderAccessor headerAccessor) {
 
         Map<String, Object> attributes = headerAccessor.getSessionAttributes();
         if (attributes == null) {
@@ -61,19 +82,25 @@ public class TestrunMessageController {
         }
 
         Long userId = Long.parseLong((String) attributes.get("USER-ID"));
+        String sessionId = headerAccessor.getSessionId();
 
-        testrunService.deleteTestrunParticipantInfo(spaceCode, projectId, testrunId, userId);
+        TestrunParticipantDTO participant = testrunService.selectTestrunParticipantInfo(spaceCode, projectId, testrunId, userId, sessionId);
+        if (participant != null) {
+            testrunService.deleteTestrunParticipantInfo(participant);
+            boolean isExist = testrunService.isExistParticipant(testrunId, userId);
+            if (!isExist) {
+                MessageData participantData = MessageData.builder().type("TESTRUN-USER-LEAVE").build();
+                participantData.addData("participant", participant);
+                messageSendService.sendTo("projects/" + participant.getProjectId() + "/testruns/" + participant.getTestrunId(), participantData);
+            }
+        }
 
-        List<TestrunParticipantDTO> participants = testrunService.selectTestrunParticipantList(testrunId, userId);
-        participants.forEach((participant) -> {
-            MessageData participantData = MessageData.builder().type("TESTRUN-USER-LEAVE").build();
-            participantData.addData("participant", participant);
-            messageSendService.sendTo("projects/" + participant.getProjectId() + "/testruns/" + participant.getTestrunId(), participantData);
-        });
     }
 
     @MessageMapping("/{testrunId}/testcases/{testcaseId}/watch")
-    public void join(@DestinationVariable(value = "spaceCode") String spaceCode, @DestinationVariable(value = "projectId") Long projectId, @DestinationVariable(value = "testrunId") Long testrunId, @DestinationVariable(value = "testcaseId") Long testcaseId,  SimpMessageHeaderAccessor headerAccessor) {
+    public void join(@DestinationVariable(value = "spaceCode") String spaceCode, @DestinationVariable(value = "projectId") Long projectId,
+        @DestinationVariable(value = "testrunId") Long testrunId, @DestinationVariable(value = "testcaseId") Long testcaseId,
+        SimpMessageHeaderAccessor headerAccessor) {
 
         Map<String, Object> attributes = headerAccessor.getSessionAttributes();
         if (attributes == null) {
@@ -84,9 +111,9 @@ public class TestrunMessageController {
         Long userId = Long.parseLong((String) attributes.get("USER-ID"));
         String userEmail = (String) attributes.get("USER-EMAIL");
         MessageData participantData = MessageData.builder().type("TESTRUN-TESTCASE-WATCH").build();
-        participantData.addData("userId" , userId);
-        participantData.addData("userEmail" , userEmail);
-        participantData.addData("testcaseId" , testcaseId);
+        participantData.addData("userId", userId);
+        participantData.addData("userEmail", userEmail);
+        participantData.addData("testcaseId", testcaseId);
         messageSendService.sendTo("projects/" + projectId + "/testruns/" + testrunId, participantData);
     }
 

--- a/src/main/java/com/mindplates/bugcase/biz/testrun/dto/TestrunParticipantDTO.java
+++ b/src/main/java/com/mindplates/bugcase/biz/testrun/dto/TestrunParticipantDTO.java
@@ -17,6 +17,7 @@ public class TestrunParticipantDTO {
     private String spaceCode;
     private Long projectId;
     private Long testrunId;
+    private String sessionId;
     private Long userId;
     private String userEmail;
     private String userName;
@@ -26,6 +27,7 @@ public class TestrunParticipantDTO {
         this.id = testrunParticipant.getId();
         this.spaceCode = testrunParticipant.getSpaceCode();
         this.projectId = testrunParticipant.getProjectId();
+        this.sessionId = testrunParticipant.getSessionId();
         this.testrunId = testrunParticipant.getTestrunId();
         this.userId = testrunParticipant.getUserId();
         this.userEmail = testrunParticipant.getUserEmail();

--- a/src/main/java/com/mindplates/bugcase/biz/testrun/entity/TestrunParticipant.java
+++ b/src/main/java/com/mindplates/bugcase/biz/testrun/entity/TestrunParticipant.java
@@ -22,6 +22,8 @@ public class TestrunParticipant {
     @Indexed
     private Long testrunId;
     @Indexed
+    private String sessionId;
+    @Indexed
     private Long userId;
     private String userEmail;
     private String userName;

--- a/src/main/java/com/mindplates/bugcase/biz/testrun/repository/TestrunParticipantRedisRepository.java
+++ b/src/main/java/com/mindplates/bugcase/biz/testrun/repository/TestrunParticipantRedisRepository.java
@@ -12,4 +12,7 @@ public interface TestrunParticipantRedisRepository extends CrudRepository<Testru
 
     List<TestrunParticipant> findAllByTestrunIdAndUserId(Long testrunId, Long userId);
 
+    List<TestrunParticipant> findAllByUserIdAndSessionId(Long userId, String sessionId);
+
+
 }


### PR DESCRIPTION
### 📄 What is this PR? 
- 테스트런에 현재 참가자 중인 사용자 목록이 동기화 되지 않는 오류 수정
- #122 

### 🛠 Changes
- 사용자가 브라우저를 종료하는 경우, 테스트런 참가자 정보 삭제 및 참가 여부를 전송하도록 수정
- 사용자의 웹소켓 세션 아이디를 기반으로 참가 정보를 관리하도록 변경

### 📸 Screenshots (Optional)
![image](https://github.com/case-book/casebook/assets/14084781/a4a14253-558e-4e39-8411-b2b1655a5e74)